### PR TITLE
Use protocol-relative URL for Google API

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,7 +227,7 @@
       &copy; 2014 Victor Fernández / <a href="http://vctrfrnndz.com/">@vctrfrnndz</a> / <a href="mailto:victor@vctrfrnndz.com">email</a> / <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=victor%2emin%2ejs%40gmail%2ecom&lc=US&item_name=jQuery%20Accordion%20Plugin&no_note=0&currency_code=USD&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHostedGuest" >donate</a>
     </section>
 
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script type="text/javascript" src="js/jquery.accordion.js"></script>
     <script type="text/javascript">
       $(document).ready(function() {


### PR DESCRIPTION
GitHub Pages can now be served via SSL. Requesting JS via HTTP will be blocked by default.
